### PR TITLE
fix: ensure docker image can be built without a local binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM golang:alpine
+FROM golang:1.13.4-alpine
 
-COPY pod-reaper /pod-reaper
+RUN apk --no-cache add curl git && curl https://glide.sh/get | sh && apk del curl
+
+WORKDIR /go/src/app
+COPY ["glide.yaml", "main.go", "/go/src/app/"]
+
+RUN glide install
+
+RUN go build -o /pod-reaper
+
 CMD  /pod-reaper


### PR DESCRIPTION
Building the image was otherwise completely broken since it depended on the binary being built outside of the container.